### PR TITLE
pip install fails due to missing Readme.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import (
 
 
 def readme():
-    with open('README.rst') as f:
+    with open('README.md') as f:
         return f.read()
 
 


### PR DESCRIPTION
In the [setup.py](https://github.com/cburkert/fuzzy-commitment/blob/master/setup.py) the creation of the readme is defined expecting a Readme.rst file.
This file is not present. Instead a README.md can be found.

Changing the filename in [setup.py](https://github.com/cburkert/fuzzy-commitment/blob/master/setup.py) to README.md fixes pip install.